### PR TITLE
Fix closing curly brace bug

### DIFF
--- a/bin/js_code_linter.rb
+++ b/bin/js_code_linter.rb
@@ -35,10 +35,10 @@ File.open('code.js', 'r') do |file|
       else
         message = ErrorMessage.new(line, sections[section_index - 1])
         output = message.generate_message(number + 1)
-        if !output.empty?
+        if !output.empty? && !output.eql?('Section closed')
           puts output
           errors += 1
-        elsif output.empty? && !sections[section_index - 1]&.is_open
+        elsif !output.empty? && !sections[section_index - 1]&.is_open && output.eql?('Section closed')
           tab_no -= 1
           section_index -= 1
         end

--- a/lib/error_message.rb
+++ b/lib/error_message.rb
@@ -24,7 +24,7 @@ class ErrorMessage
     elsif code_line.closed_curly_braces?
       if @prev_section&.is_open
         @prev_section.is_open = false
-        return ''
+        return 'Section closed'
       end
       return "Remove extra closing curely braces (}) at line #{line_no}" unless @prev_section&.is_open
     elsif @prev_section&.is_open

--- a/spec/error_message_spec.rb
+++ b/spec/error_message_spec.rb
@@ -38,7 +38,7 @@ describe ErrorMessage do
     it 'returns a blank message if the section is open & the line contains a closing curly brace' do
       c_section = CodeSection.new(1, 5, true)
       message = ErrorMessage.new('}', c_section)
-      expect(message.generate_message(5)).to eql('')
+      expect(message.generate_message(5)).to eql('Section closed')
     end
     it 'returns a message indicating an extra closing curly brace if the section is already closed' do
       c_section = CodeSection.new(1, 6, false)


### PR DESCRIPTION
In this pull request, I fixed a major bug in the error_message class that occurs when a code section is closed.